### PR TITLE
fixes for Spring plugin POM missing on remote repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<java.version>11</java.version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<dependencies>
@@ -57,6 +58,8 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<!-- required because of missing POM of newest (SNAPSHOT) version -->
+				<version>2.3.0.BUILD-20200111.072712-105</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
There were some issues regarding newest version of Spring boot plugin.
The POM file is missing on th Spring Maven repo:

* https://repo.spring.io/snapshot/org/springframework/boot/spring-boot-maven-plugin/2.3.0.BUILD-SNAPSHOT/

This pull request specifies previous version of plugin.
And also adds settings to specify source files encoding as UTF-8.