### PR TITLE
removing fixed plugin version as the POM is now present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<!-- required because of missing POM of newest (SNAPSHOT) version -->
-				<version>2.3.0.BUILD-20200111.072712-105</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Removin a fix for missing POM of Spring Boot Maven plugin (see pull request https://github.com/Qbunjo/stunt/pull/1).
It is no longer needed ([new version with POM](https://repo.spring.io/snapshot/org/springframework/boot/spring-boot-maven-plugin/2.3.0.BUILD-SNAPSHOT/) was added).