### PR TITLE
adding a Service that returns currently logged user

### DIFF
--- a/src/main/java/pl/jakalski/stunt/security/CurrentUserService.java
+++ b/src/main/java/pl/jakalski/stunt/security/CurrentUserService.java
@@ -1,0 +1,12 @@
+package pl.jakalski.stunt.security;
+
+public interface CurrentUserService {
+
+    /**
+     * Will return username of logged user or null if there were no authentication.
+     *
+     * @return id of current user.
+     */
+    String retrieveUsername();
+
+}

--- a/src/main/java/pl/jakalski/stunt/security/CurrentUserServiceImpl.java
+++ b/src/main/java/pl/jakalski/stunt/security/CurrentUserServiceImpl.java
@@ -1,0 +1,13 @@
+package pl.jakalski.stunt.security;
+
+import org.springframework.stereotype.Service;
+
+@Service
+class CurrentUserServiceImpl implements CurrentUserService {
+
+    @Override
+    public String retrieveUsername() {
+        // we will provide correct implementation later...
+        return "user01";
+    }
+}

--- a/src/test/java/pl/jakalski/stunt/security/CurrentUserServiceForTests.java
+++ b/src/test/java/pl/jakalski/stunt/security/CurrentUserServiceForTests.java
@@ -1,0 +1,15 @@
+package pl.jakalski.stunt.security;
+
+public class CurrentUserServiceForTests implements CurrentUserService {
+
+    private final String currentUser;
+
+    public CurrentUserServiceForTests(String currentUser) {
+        this.currentUser = currentUser;
+    }
+
+    @Override
+    public String retrieveUsername() {
+        return currentUser;
+    }
+}


### PR DESCRIPTION
One of the features provided by Spring is [dependency injection](https://www.baeldung.com/spring-dependency-injection).

It can be used as a way to provide external dependencies for Spring components.

In order for a dependency to be injected it needs to be registered as a `@Service`.

This pull request creates a service that can be used to retrieve logged user.
There is also a test version of this service - for use in unit tests.